### PR TITLE
chore(main): update svggen import paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	svggen2 "github.com/2ajoyce/dynamic-readme-elements/internal/svggen"
+	"github.com/2ajoyce/dynamic-readme-elements/internal/svggen"
 	"github.com/gin-gonic/gin"
 )
 
@@ -9,13 +9,13 @@ func main() {
 	router := gin.Default()
 
 	// Route for a calendar
-	router.GET("/calendar", svggen2.HandleCalendar)
+	router.GET("/calendar", svggen.HandleCalendar)
 
 	// Route for a rectangular loading bar
-	router.GET("/progress/bar", svggen2.HandleProgressBar)
+	router.GET("/progress/bar", svggen.HandleProgressBar)
 
 	// Route for a circular progress bar
-	router.GET("/progress/circle", svggen2.HandleProgressCircle)
+	router.GET("/progress/circle", svggen.HandleProgressCircle)
 
 	err := router.Run(":8080")
 	if err != nil {


### PR DESCRIPTION
Refactor import paths to use the directly referenced package instead of aliasing, updating the "main.go" file.