### PR TITLE
feat(svggen): add progress waffle chart route and generation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This project provides a Go API using the Gin framework for generating customizab
 
 ## Features
 
-- **Linear Progress Bar**: Generates a horizontal bar indicating progress.
-- **Circular Progress Bar**: Creates a circular, "donut" style progress indicator.
-- **Calendar Progress Chart**: Displays a monthly calendar with marked progress days.
-- **Customizable**: Adjust size, percentage, and other properties via query parameters.
+- **Linear Progress Bar**: Generates a horizontal bar to visually represent progress. Customizable in size and fill percentage.
+- **Circular Progress Bar**: Creates a circular or "donut" style progress indicator. Size and progress fill are adjustable.
+- **Waffle Progress Chart**: Displays progress in a grid or 'waffle' format. Offers customization in grid size, square count, and filled percentage.
+- **Calendar Progress Chart**: Shows a monthly calendar view with specific days marked to indicate progress. Customizable by year, month, and progress days.
 
 ## Getting Started
 
@@ -39,17 +39,25 @@ Generate SVG progress bars by accessing the endpoints with specific query parame
 
 - **Endpoint**: `/progress/bar`
 - **Parameters**: `width`, `height`, `percentage`
-- **Example**: `http://localhost:8080/progress/bar?width=300&height=50&percentage=72`
+- **Example**: `http://localhost:8080/progress/bar?width=100&height=25&percentage=72`
 
-![Linear Progress Bar](https://progress.2ajoyce.com/progress/bar?width=300&height=50&percentage=72)
+![Linear Progress Bar](https://progress.2ajoyce.com/progress/bar?width=100&height=25&percentage=72)
 
 ### Circular Progress Bar
 
 - **Endpoint**: `/progress/circle`
 - **Parameters**: `size`, `percentage`
-- **Example**: `http://localhost:8080/progress/circle?size=120&percentage=72`
+- **Example**: `http://localhost:8080/progress/circle?size=100&percentage=72`
 
-![Circular Progress Bar](https://progress.2ajoyce.com/progress/circle?size=120&percentage=72)
+![Circular Progress Bar](https://progress.2ajoyce.com/progress/circle?size=100&percentage=72)
+
+### Waffle Progress Chart
+
+- **Endpoint**: `/progress/waffle`
+- **Parameters**: `width`, `numberOfSquares`,`percentage`
+- **Example**: `http://localhost:8080/progress/waffle?width=100&numberOfSquares=100&percentage=99`
+
+![Waffle Progress Chart](https://progress.2ajoyce.com/progress/waffle?width=100&numberOfSquares=100&percentage=99)
 
 ### Calendar Progress Chart
 
@@ -62,12 +70,12 @@ Generate SVG progress bars by accessing the endpoints with specific query parame
 
 ## Customization
 
-Modify query parameters for customization:
+Each progress indicator type offers specific customization options through query parameters:
 
-- width and height for the linear bar (in pixels).
-- size for the diameter of the circular bar (in pixels).
-- percentage for progress representation (0 to 100).
-- For the calendar chart, year, month, and progressDays to mark specific days.
+- **Linear Progress Bar**: Adjust the `width`, `height`, and `percentage` to control the bar's dimensions and progress.
+- **Circular Progress Bar**: Modify the `size` for the diameter and `percentage` for progress representation.
+- **Waffle Progress Chart**: Change the `width` to control the overall size, `numberOfSquares` for grid density, and `percentage` for filled squares.
+- **Calendar Progress Chart**: Set `year`, `month`, and optionally `progressDays` to display progress on specific days of a month.
 
 ## Acknowledgments
 

--- a/internal/svggen/calendar.go
+++ b/internal/svggen/calendar.go
@@ -46,7 +46,7 @@ func hasElem(slice []int, elem int) bool {
 const calendarChartTemplateStr = `
 		<svg width="370px" height="310px" xmlns="http://www.w3.org/2000/svg" font-family="Arial">
 			<!-- Background with rounded corners and padding -->
-			<rect x="5" y="5" width="360px" height="300px" fill="white" rx="15" /> <!-- Adjust as needed -->
+			<rect x="5" y="5" width="360px" height="300px" fill="white" rx="15" />
 
 			<!-- Header for month and year -->
 			<text x="180" y="35" font-size="20" text-anchor="middle" fill="black">{{.MonthName}} {{.Year}}</text>

--- a/internal/svggen/colors.go
+++ b/internal/svggen/colors.go
@@ -1,0 +1,17 @@
+package svggen
+
+// ColorSet defines a set of color constants
+type ColorSet struct {
+	ProgressActive   string
+	ProgressInactive string
+	White            string
+	Black            string
+}
+
+// Colors holds the application-wide color constants
+var Colors = ColorSet{
+	ProgressActive:   "#44CC11",
+	ProgressInactive: "#7A7A7A",
+	White:            "white",
+	Black:            "black",
+}

--- a/internal/svggen/progress_bar.go
+++ b/internal/svggen/progress_bar.go
@@ -8,9 +8,9 @@ import (
 
 const rectTemplateStr = `
 		<svg width="{{.Width}}px" height="{{.Height}}px" xmlns="http://www.w3.org/2000/svg">
-			<rect rx="3" ry="3" x="0" y="0" width="{{.Width}}px" height="{{.Height}}px" fill="#555" />
-			<rect rx="3" ry="3" x="0" y="0" width="{{.FillWidth}}px" height="{{.Height}}px" fill="#4c1" />
-			<text x="{{.TextX}}px" y="{{.TextY}}px" font-size="{{.FontSize}}px" dominant-baseline="central" text-anchor="middle" fill="#fff" font-family="Arial, Helvetica, sans-serif" font-weight="bold">{{.Percentage}}%</text>
+			<rect rx="3" ry="3" x="0" y="0" width="{{.Width}}px" height="{{.Height}}px" fill="{{.ColorInactive}}" />
+			<rect rx="3" ry="3" x="0" y="0" width="{{.FillWidth}}px" height="{{.Height}}px" fill="{{.ColorActive}}" />
+			<text x="{{.TextX}}px" y="{{.TextY}}px" font-size="{{.FontSize}}px" dominant-baseline="central" text-anchor="middle" fill="{{.ColorWhite}}" font-family="Arial, Helvetica, sans-serif" font-weight="bold">{{.Percentage}}%</text>
 		</svg>
 		`
 
@@ -30,15 +30,19 @@ func HandleProgressBar(c *gin.Context) {
 	fillWidth := (width * percentage) / 100
 
 	data := struct {
+		ColorActive, ColorInactive, ColorWhite                       string
 		Width, Height, FillWidth, TextX, TextY, FontSize, Percentage int
 	}{
-		Width:      width,
-		Height:     height,
-		FillWidth:  fillWidth,
-		TextX:      width / 2,
-		TextY:      height / 2,
-		FontSize:   height / 2,
-		Percentage: percentage,
+		ColorActive:   Colors.ProgressActive,
+		ColorInactive: Colors.ProgressInactive,
+		ColorWhite:    Colors.White,
+		Width:         width,
+		Height:        height,
+		FillWidth:     fillWidth,
+		TextX:         width / 2,
+		TextY:         height / 2,
+		FontSize:      height / 2,
+		Percentage:    percentage,
 	}
 
 	c.Writer.Header().Set("Content-Type", "image/svg+xml")

--- a/internal/svggen/progress_bar_test.go
+++ b/internal/svggen/progress_bar_test.go
@@ -1,6 +1,7 @@
 package svggen
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -24,7 +25,7 @@ func TestHandleProgressBar(t *testing.T) {
 			name:           "Normal case",
 			queryString:    "/progress/bar?width=221&height=33&percentage=54",
 			expectedStatus: http.StatusOK,
-			expectedInBody: []string{"width=\"221px\"", "height=\"33px\"", "fill=\"#4c1\"", "54%"},
+			expectedInBody: []string{"width=\"221px\"", "height=\"33px\"", fmt.Sprintf("fill=\"%s\"", Colors.ProgressActive), "54%"},
 		},
 		{
 			name:           "Normal case - Full Template",
@@ -32,9 +33,9 @@ func TestHandleProgressBar(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedInBody: []string{
 				`<svg width="221px" height="33px" xmlns="http://www.w3.org/2000/svg">`,
-				`<rect rx="3" ry="3" x="0" y="0" width="221px" height="33px" fill="#555" />`,
-				`<rect rx="3" ry="3" x="0" y="0" width="119px" height="33px" fill="#4c1" />`,
-				`<text x="110px" y="16px" font-size="16px" dominant-baseline="central" text-anchor="middle" fill="#fff" font-family="Arial, Helvetica, sans-serif" font-weight="bold">54%</text>`,
+				fmt.Sprintf("<rect rx=\"3\" ry=\"3\" x=\"0\" y=\"0\" width=\"221px\" height=\"33px\" fill=\"%s\" />", Colors.ProgressInactive),
+				fmt.Sprintf("<rect rx=\"3\" ry=\"3\" x=\"0\" y=\"0\" width=\"119px\" height=\"33px\" fill=\"%s\" />", Colors.ProgressActive),
+				fmt.Sprintf("<text x=\"110px\" y=\"16px\" font-size=\"16px\" dominant-baseline=\"central\" text-anchor=\"middle\" fill=\"%s\" font-family=\"Arial, Helvetica, sans-serif\" font-weight=\"bold\">54%%</text>", Colors.White),
 				`</svg>`,
 			},
 		},
@@ -42,13 +43,13 @@ func TestHandleProgressBar(t *testing.T) {
 			name:           "Percentage below zero",
 			queryString:    "/progress/bar?width=200&height=30&percentage=-10",
 			expectedStatus: http.StatusOK,
-			expectedInBody: []string{"width=\"200px\"", "height=\"30px\"", "fill=\"#555\"", "0%"},
+			expectedInBody: []string{"width=\"200px\"", "height=\"30px\"", fmt.Sprintf("fill=\"%s\"", Colors.ProgressInactive), "0%"},
 		},
 		{
 			name:           "Percentage above 100",
 			queryString:    "/progress/bar?width=200&height=30&percentage=150",
 			expectedStatus: http.StatusOK,
-			expectedInBody: []string{"width=\"200px\"", "height=\"30px\"", "fill=\"#4c1\"", "100%"},
+			expectedInBody: []string{"width=\"200px\"", "height=\"30px\"", fmt.Sprintf("fill=\"%s\"", Colors.ProgressActive), "100%"},
 		},
 	}
 

--- a/internal/svggen/progress_circle.go
+++ b/internal/svggen/progress_circle.go
@@ -9,9 +9,9 @@ import (
 const circleTemplateStr = `
 
 	<svg height="{{.Size}}px" width="{{.Size}}px" viewBox="0 0 {{.Size}} {{.Size}}" xmlns="http://www.w3.org/2000/svg">
-		<circle cx="{{.Center}}" cy="{{.Center}}" r="{{.Radius}}" stroke="lightgrey" stroke-width="{{.StrokeWidth}}" fill="white" />
-		<circle cx="{{.Center}}" cy="{{.Center}}" r="{{.Radius}}" stroke="#4c1" stroke-width="{{.StrokeWidth}}" fill="none" stroke-dasharray="{{.StrokeDasharrayFilled}}, {{.StrokeDasharrayUnfilled}}" stroke-dashoffset="0" transform="rotate(-90, {{.Center}}, {{.Center}})" />
-		<text x="{{.Center}}" y="{{.Center}}" font-size="{{.FontSize}}px" dominant-baseline="central" text-anchor="middle" fill="black" font-family="Arial, Helvetica, sans-serif" font-weight="bold">{{.Percentage}}%</text>
+		<circle cx="{{.Center}}" cy="{{.Center}}" r="{{.Radius}}" stroke="{{.ColorInactive}}" stroke-width="{{.StrokeWidth}}" fill="{{.ColorWhite}}" />
+		<circle cx="{{.Center}}" cy="{{.Center}}" r="{{.Radius}}" stroke="{{.ColorActive}}" stroke-width="{{.StrokeWidth}}" fill="none" stroke-dasharray="{{.StrokeDasharrayFilled}}, {{.StrokeDasharrayUnfilled}}" stroke-dashoffset="0" transform="rotate(-90, {{.Center}}, {{.Center}})" />
+		<text x="{{.Center}}" y="{{.Center}}" font-size="{{.FontSize}}px" dominant-baseline="central" text-anchor="middle" fill="{{.ColorBlack}}" font-family="Arial, Helvetica, sans-serif" font-weight="bold">{{.Percentage}}%</text>
 	</svg>
 	`
 
@@ -34,9 +34,14 @@ func HandleProgressCircle(c *gin.Context) {
 	strokeDasharrayUnfilled := circumference - strokeDasharrayFilled
 
 	data := struct {
+		ColorActive, ColorInactive, ColorWhite, ColorBlack                       string
 		Size, StrokeWidth, Percentage                                            int
 		Radius, StrokeDasharrayFilled, StrokeDasharrayUnfilled, FontSize, Center float64
 	}{
+		ColorActive:             Colors.ProgressActive,
+		ColorInactive:           Colors.ProgressInactive,
+		ColorWhite:              Colors.White,
+		ColorBlack:              Colors.Black,
 		Size:                    size,
 		StrokeWidth:             strokeWidth,
 		Percentage:              percentage,

--- a/internal/svggen/progress_circle_test.go
+++ b/internal/svggen/progress_circle_test.go
@@ -1,6 +1,7 @@
 package svggen
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -32,9 +33,9 @@ func TestHandleProgressCircle(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedInBody: []string{
 				`<svg height="103px" width="103px" viewBox="0 0 103 103" xmlns="http://www.w3.org/2000/svg">`,
-				`<circle cx="51.5" cy="51.5" r="36.5" stroke="lightgrey" stroke-width="15" fill="white" />`,
-				`<circle cx="51.5" cy="51.5" r="36.5" stroke="#4c1" stroke-width="15" fill="none" stroke-dasharray="132.9476, 96.2724" stroke-dashoffset="0" transform="rotate(-90, 51.5, 51.5)" />`,
-				`<text x="51.5" y="51.5" font-size="20.6px" dominant-baseline="central" text-anchor="middle" fill="black" font-family="Arial, Helvetica, sans-serif" font-weight="bold">58%</text>`,
+				fmt.Sprintf("<circle cx=\"51.5\" cy=\"51.5\" r=\"36.5\" stroke=\"%s\" stroke-width=\"15\" fill=\"%s\" />", Colors.ProgressInactive, Colors.White),
+				fmt.Sprintf("<circle cx=\"51.5\" cy=\"51.5\" r=\"36.5\" stroke=\"%s\" stroke-width=\"15\" fill=\"none\" stroke-dasharray=\"132.9476, 96.2724\" stroke-dashoffset=\"0\" transform=\"rotate(-90, 51.5, 51.5)\" />", Colors.ProgressActive),
+				fmt.Sprintf("text x=\"51.5\" y=\"51.5\" font-size=\"20.6px\" dominant-baseline=\"central\" text-anchor=\"middle\" fill=\"%s\" font-family=\"Arial, Helvetica, sans-serif\" font-weight=\"bold\">58%%</text>", Colors.Black),
 				`</svg>`,
 			},
 		},

--- a/internal/svggen/progress_waffle.go
+++ b/internal/svggen/progress_waffle.go
@@ -1,0 +1,153 @@
+package svggen
+
+import (
+	"github.com/gin-gonic/gin"
+	"html/template"
+	"log"
+	"math"
+	"strconv"
+)
+
+const waffleChartTemplateStr = `
+<svg width="{{.Width}}px" height="{{.Height}}px" xmlns="http://www.w3.org/2000/svg">
+	<rect x="0" y="0" width="{{.Width}}px" height="{{.Height}}px" fill="none" />
+    {{range .Squares}}
+        <rect class="gridSquare" x="{{.X}}px" y="{{.Y}}px" width="{{$.SquareSize}}px" height="{{$.SquareSize}}px" fill="{{.Color}}" />
+    {{end}}
+</svg>
+`
+
+var waffleChartTemplate = template.Must(template.New("waffleChart").Parse(waffleChartTemplateStr))
+
+func CalculateGridSize(width, numberOfSquares, gap int) (int, int) {
+	// Validate the inputs
+	if width <= 0 {
+		width = 100
+	}
+	if numberOfSquares <= 0 {
+		numberOfSquares = 100
+	}
+
+	// Estimate the number of squares per row
+	estimatedSquaresPerRow := int(math.Sqrt(float64(numberOfSquares)))
+
+	// Calculate the total gap space for the estimated number of squares per row
+	totalGapSpace := (estimatedSquaresPerRow - 1) * gap
+
+	// Adjust the width to account for the gaps
+	adjustedWidth := width - totalGapSpace
+
+	// Calculate the ideal size of each square based on the adjusted width
+	idealSquareSize := int(math.Max(10, float64(adjustedWidth)/float64(estimatedSquaresPerRow)))
+
+	// Recalculate the number of squares per row based on the ideal square size
+	squaresPerRow := adjustedWidth / idealSquareSize
+
+	// Ensure there is at least one square per row
+	if squaresPerRow == 0 {
+		squaresPerRow = 1
+	}
+
+	// Calculate the number of squares per column
+	squaresPerColumn := numberOfSquares / squaresPerRow
+
+	// Adjust for any remaining squares
+	if numberOfSquares%squaresPerRow != 0 {
+		squaresPerColumn++
+	}
+
+	return squaresPerRow, squaresPerColumn
+}
+
+func GenerateSquares(width, squaresPerRow, numberOfSquares, filledSquares, gap int) []struct {
+	X, Y  int
+	Color string
+} {
+	squares := make([]struct {
+		X, Y  int
+		Color string
+	}, numberOfSquares)
+
+	// Calculate total available width for squares, excluding gaps
+	totalWidthForSquares := width - (gap * (squaresPerRow - 1))
+
+	// Calculate width of each square
+	squareWidth := totalWidthForSquares / squaresPerRow
+
+	// Calculate the extra width to be distributed among squares
+	extraWidthPerSquare := (totalWidthForSquares % squaresPerRow) / squaresPerRow
+
+	for i := 0; i < numberOfSquares; i++ {
+		// Calculate the X and Y position, including gaps and extra width
+		x := gap + (i%squaresPerRow)*(squareWidth+gap+extraWidthPerSquare)
+		y := gap + (i/squaresPerRow)*(squareWidth+gap)
+
+		color := Colors.ProgressInactive // Default color for unfilled squares
+		if i < filledSquares {
+			color = Colors.ProgressActive // Color for filled squares
+		}
+
+		squares[i] = struct {
+			X, Y  int
+			Color string
+		}{X: x, Y: y, Color: color}
+	}
+	return squares
+}
+
+func clamp(value, min, max int) int {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func HandleProgressWaffle(c *gin.Context) {
+	width := parseOrDefault(c.DefaultQuery("width", "100"), 10) // Minimum width is 10
+	numberOfSquares := parseOrDefault(c.DefaultQuery("numberOfSquares", "100"), 100)
+	gap := 3 // Gap between squares
+
+	squaresPerRow, squaresPerColumn := CalculateGridSize(width, numberOfSquares, gap)
+
+	// Calculate the adjusted width to account for the gaps
+	totalGapSpace := (squaresPerRow - 1) * gap
+	adjustedWidth := width - totalGapSpace
+
+	// Calculate the size of each square based on the adjusted width
+	squareSize := adjustedWidth / squaresPerRow
+
+	height := (squareSize+gap)*squaresPerColumn - gap // Adjust the height to include gaps between rows
+
+	percentage := clamp(parseOrDefault(c.DefaultQuery("percentage", "0"), 0), 0, 100)
+	filledSquares := numberOfSquares * percentage / 100
+
+	squares := GenerateSquares(width, squaresPerRow, numberOfSquares, filledSquares, gap)
+
+	data := struct {
+		Width, Height, SquareSize int
+		Squares                   []struct {
+			X, Y  int
+			Color string
+		}
+	}{
+		Width:      ((squareSize + gap) * squaresPerRow) + gap,
+		Height:     height + 2*gap,
+		SquareSize: squareSize,
+		Squares:    squares,
+	}
+
+	c.Writer.Header().Set("Content-Type", "image/svg+xml")
+	if err := waffleChartTemplate.Execute(c.Writer, data); err != nil {
+		log.Printf("Error executing waffle chart template: %v\n", err)
+	}
+}
+
+func parseOrDefault(value string, defaultVal int) int {
+	if parsed, err := strconv.Atoi(value); err == nil {
+		return parsed
+	}
+	return defaultVal
+}

--- a/internal/svggen/progress_waffle_test.go
+++ b/internal/svggen/progress_waffle_test.go
@@ -1,0 +1,343 @@
+package svggen
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestCalculateGridSize(t *testing.T) {
+	testCases := []struct {
+		name            string
+		width           int
+		numberOfSquares int
+		expectedRows    int
+		expectedColumns int
+	}{
+		{
+			name:            "Standard case",
+			width:           300,
+			numberOfSquares: 100,
+			expectedRows:    10,
+			expectedColumns: 10,
+		},
+		{
+			name:            "Width less than ideal square size",
+			width:           5,
+			numberOfSquares: 25,
+			expectedRows:    1,
+			expectedColumns: 25,
+		},
+		{
+			name:            "Width leading to fractional squares",
+			width:           300,
+			numberOfSquares: 105,
+			expectedRows:    10,
+			expectedColumns: 11,
+		},
+		{
+			name:            "Minimum width",
+			width:           1,
+			numberOfSquares: 10,
+			expectedRows:    1,
+			expectedColumns: 10,
+		},
+		{
+			name:            "Large number of squares",
+			width:           300,
+			numberOfSquares: 1000,
+			expectedRows:    21,
+			expectedColumns: 48,
+		},
+		{
+			name:            "Width exactly divisible by square size",
+			width:           300,
+			numberOfSquares: 90, // 30x30 squares
+			expectedRows:    9,
+			expectedColumns: 10,
+		},
+		{
+			name:            "Odd number of squares",
+			width:           300,
+			numberOfSquares: 99,
+			expectedRows:    9,
+			expectedColumns: 11,
+		},
+		{
+			name:            "Zero width",
+			width:           0,
+			numberOfSquares: 100,
+			expectedRows:    7,
+			expectedColumns: 15,
+		},
+		{
+			name:            "Negative width",
+			width:           -300,
+			numberOfSquares: 100,
+			expectedRows:    7,
+			expectedColumns: 15,
+		}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, columns := CalculateGridSize(tc.width, tc.numberOfSquares, 3)
+
+			if rows != tc.expectedRows || columns != tc.expectedColumns {
+				t.Errorf("Test %s failed: expected (%d, %d), got (%d, %d)", tc.name, tc.expectedRows, tc.expectedColumns, rows, columns)
+			}
+		})
+	}
+}
+
+func TestGenerateSquares(t *testing.T) {
+	testCases := []struct {
+		name            string
+		squaresPerRow   int
+		width           int
+		numberOfSquares int
+		filledSquares   int
+		expectedSquares []struct {
+			X, Y  int
+			Color string
+		}
+	}{
+		{
+			name:            "Small mix case",
+			squaresPerRow:   5,
+			width:           100,
+			numberOfSquares: 10,
+			filledSquares:   6,
+			expectedSquares: []struct {
+				X, Y  int
+				Color string
+			}{
+				{3, 3, Colors.ProgressActive},
+				{23, 3, Colors.ProgressActive},
+				{43, 3, Colors.ProgressActive},
+				{63, 3, Colors.ProgressActive},
+				{83, 3, Colors.ProgressActive},
+				{3, 23, Colors.ProgressActive},
+				{23, 23, Colors.ProgressInactive},
+				{43, 23, Colors.ProgressInactive},
+				{63, 23, Colors.ProgressInactive},
+				{83, 23, Colors.ProgressInactive},
+			},
+		},
+		{
+			name:            "All squares filled",
+			squaresPerRow:   5,
+			width:           100,
+			numberOfSquares: 10,
+			filledSquares:   10,
+			expectedSquares: []struct {
+				X, Y  int
+				Color string
+			}{
+				{3, 3, Colors.ProgressActive},
+				{23, 3, Colors.ProgressActive},
+				{43, 3, Colors.ProgressActive},
+				{63, 3, Colors.ProgressActive},
+				{83, 3, Colors.ProgressActive},
+				{3, 23, Colors.ProgressActive},
+				{23, 23, Colors.ProgressActive},
+				{43, 23, Colors.ProgressActive},
+				{63, 23, Colors.ProgressActive},
+				{83, 23, Colors.ProgressActive},
+			},
+		},
+		{
+			name:            "No squares filled",
+			squaresPerRow:   5,
+			width:           100,
+			numberOfSquares: 10,
+			filledSquares:   0,
+			expectedSquares: []struct {
+				X, Y  int
+				Color string
+			}{
+				{3, 3, Colors.ProgressInactive},
+				{23, 3, Colors.ProgressInactive},
+				{43, 3, Colors.ProgressInactive},
+				{63, 3, Colors.ProgressInactive},
+				{83, 3, Colors.ProgressInactive},
+				{3, 23, Colors.ProgressInactive},
+				{23, 23, Colors.ProgressInactive},
+				{43, 23, Colors.ProgressInactive},
+				{63, 23, Colors.ProgressInactive},
+				{83, 23, Colors.ProgressInactive},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			squares := GenerateSquares(tc.width, tc.squaresPerRow, tc.numberOfSquares, tc.filledSquares, 3)
+
+			// Validate the number of squares generated
+			if len(squares) != tc.numberOfSquares {
+				t.Errorf("Test %s failed: expected number of squares %d, got %d", tc.name, tc.numberOfSquares, len(squares))
+			}
+
+			// Validate the position and color of each square
+			for i, expectedSquare := range tc.expectedSquares {
+				if squares[i].X != expectedSquare.X || squares[i].Y != expectedSquare.Y || squares[i].Color != expectedSquare.Color {
+					t.Errorf("Test %s failed at square %d: expected %v, got %v", tc.name, i, expectedSquare, squares[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClamp(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    int
+		min      int
+		max      int
+		expected int
+	}{
+		{
+			name:     "Value within range",
+			value:    50,
+			min:      0,
+			max:      100,
+			expected: 50,
+		},
+		{
+			name:     "Value below minimum",
+			value:    -10,
+			min:      0,
+			max:      100,
+			expected: 0,
+		},
+		{
+			name:     "Value above maximum",
+			value:    150,
+			min:      0,
+			max:      100,
+			expected: 100,
+		},
+		{
+			name:     "Value equal to minimum",
+			value:    0,
+			min:      0,
+			max:      100,
+			expected: 0,
+		},
+		{
+			name:     "Value equal to maximum",
+			value:    100,
+			min:      0,
+			max:      100,
+			expected: 100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := clamp(tc.value, tc.min, tc.max)
+			if result != tc.expected {
+				t.Errorf("Test %s failed: expected %d, got %d", tc.name, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestHandleProgressWaffle(t *testing.T) {
+	// Setup Gin with test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create router and add route
+	router := gin.Default()
+	router.GET("/progress/waffle", HandleProgressWaffle)
+
+	testCases := []struct {
+		name             string
+		query            string
+		expectedStatus   int
+		expectedFilled   int
+		expectedUnfilled int
+	}{
+		{
+			name:             "Valid request",
+			query:            "/progress/waffle?width=300&numberOfSquares=100&percentage=50",
+			expectedStatus:   http.StatusOK,
+			expectedFilled:   50,
+			expectedUnfilled: 50,
+		},
+		{
+			name:             "Width only",
+			query:            "/progress/waffle?width=200&percentage=25",
+			expectedStatus:   http.StatusOK,
+			expectedFilled:   25,
+			expectedUnfilled: 75,
+		},
+		{
+			name:             "Invalid percentage",
+			query:            "/progress/waffle?width=200&numberOfSquares=100&percentage=150",
+			expectedStatus:   http.StatusOK,
+			expectedFilled:   100, // Clamped to 100%
+			expectedUnfilled: 0,
+		},
+		{
+			name:             "Zero squares",
+			query:            "/progress/waffle?width=200&numberOfSquares=0&percentage=50",
+			expectedStatus:   http.StatusOK,
+			expectedFilled:   0,
+			expectedUnfilled: 0,
+		},
+		{
+			name:             "Negative width",
+			query:            "/progress/waffle?width=-200&numberOfSquares=100&percentage=50",
+			expectedStatus:   http.StatusOK,
+			expectedFilled:   50,
+			expectedUnfilled: 50,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tc.query, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			// Assertions for status code
+			if w.Code != tc.expectedStatus {
+				t.Errorf("Expected status %d, got %d for test %s", tc.expectedStatus, w.Code, tc.name)
+			}
+
+			// Validate the response body
+			responseBody := w.Body.String()
+			if err := validateWaffleSVG(responseBody, tc.expectedFilled, tc.expectedUnfilled); err != nil {
+				t.Errorf("Validation failed for test %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+func validateWaffleSVG(svgContent string, filledCount, unfilledCount int) error {
+	// Check basic SVG structure
+	if !strings.Contains(svgContent, "<svg") || !strings.Contains(svgContent, "</svg>") {
+		return errors.New("missing SVG tags")
+	}
+
+	// Use regular expressions to match squares regardless of attribute order
+	filledRegex := regexp.MustCompile(fmt.Sprintf(`class="gridSquare"[^>]*fill="%s"`, Colors.ProgressActive))
+	unfilledRegex := regexp.MustCompile(fmt.Sprintf(`class="gridSquare"[^>]*fill="%s"`, Colors.ProgressInactive))
+
+	// Count occurrences of filled and unfilled squares
+	actualFilled := len(filledRegex.FindAllStringIndex(svgContent, -1))
+	actualUnfilled := len(unfilledRegex.FindAllStringIndex(svgContent, -1))
+
+	if actualFilled != filledCount || actualUnfilled != unfilledCount {
+		return fmt.Errorf("incorrect count of filled (%d) or unfilled (%d) squares, expected filled: %d, expected unfilled: %d", actualFilled, actualUnfilled, filledCount, unfilledCount)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,9 @@ func main() {
 	// Route for a circular progress bar
 	router.GET("/progress/circle", svggen.HandleProgressCircle)
 
+	// Route for a waffle progress chart
+	router.GET("/progress/waffle", svggen.HandleProgressWaffle)
+
 	err := router.Run(":8080")
 	if err != nil {
 		return


### PR DESCRIPTION
- added handler for the progress waffle chart, including template implementation and logic for data generation. Also updated routes in main.go to include the new handlers.

- Added the waffle progress chart feature that allows users to visualize progress through a grid or 'waffle' format. This includes customization in grid size, square count, and filled percentage. The endpoint for this feature is `/progress/waffle`.