### PR TITLE
refactor(vcs): Decouple version logic and enhance Docker configuration

### DIFF
--- a/v0/internal/vcs.go
+++ b/v0/internal/vcs.go
@@ -1,0 +1,124 @@
+package internal
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/net/html"
+	"io"
+	"log"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+	"strings"
+)
+
+func HandleVersion(c *gin.Context) {
+	info, _ := debug.ReadBuildInfo()
+	vcsRevision := getCommitHashFromSettings(info.Settings)
+	var tags []string
+	if vcsRevision != "" {
+		slog.Info(fmt.Sprintf("vcs.revision=%s", vcsRevision))
+		var err error
+		tags, err = GetTagsForCommit(info.Main.Path, vcsRevision)
+		if err != nil {
+			slog.Error("Error Retrieving Version Tags", err)
+		}
+	} else {
+		slog.Error("No Commit Hash Found")
+	}
+	slog.Info(fmt.Sprintf("Tags:%+v", tags))
+	c.JSON(http.StatusOK, gin.H{"tags": tags, "revision": vcsRevision})
+}
+
+// getCommitHashFromSettings takes a slice of debug.ModuleBuildInfo and iterates over it,
+// looking for a key of "vcs.revision".
+// When found, it returns the corresponding value as a string.
+// If "vcs.revision" is not found in the settings, it returns an empty string.
+func getCommitHashFromSettings(settings []debug.BuildSetting) string {
+	var commitHash string
+	for _, setting := range settings {
+		if setting.Key == "vcs.revision" {
+			commitHash = setting.Value
+			break
+		}
+	}
+	return commitHash
+}
+
+// getOwnerAndRepo takes a string path of format "github.com/owner/repo/version"
+// and returns the "owner" and "repo" as string values.
+// Returns an error if the path format is invalid.
+func getOwnerAndRepo(path string) (string, string, error) {
+	split := strings.Split(path, "/")
+	if len(split) < 3 {
+		return "", "", fmt.Errorf("invalid path format")
+	}
+	return split[1], split[2], nil
+}
+
+// GetTagsForCommit takes a string path (format "github.com/owner/repo/version")
+// and a commit SHA string as arguments.
+// It makes a GET request to https://github.com/{owner}/{repo}/branch_commits/{commitSha},
+// parses the response body as HTML, and returns the tags associated with the commit.
+// Returns an error if the HTTP request fails, or if the HTML parsing fails.
+func GetTagsForCommit(path, commitSha string) ([]string, error) {
+	owner, repo, err := getOwnerAndRepo(path)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Get(fmt.Sprintf("https://github.com/%s/%s/branch_commits/%s", owner, repo, commitSha))
+	if err != nil {
+		return nil, err
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			log.Printf("Failed to close the response body: %v", err)
+		}
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP request failed with status code: %d", resp.StatusCode)
+	}
+
+	doc, err := html.Parse(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	tags := extractTags(doc)
+	return tags, nil
+}
+
+// extractTags takes an *html.Node and traverses the node tree,
+// extracting the text content of <a> elements within the second <ul> element it encounters.
+// Returns a slice of strings containing the extracted tags.
+func extractTags(n *html.Node) []string {
+	var ulCounter = 0
+	var result []string
+	var f func(*html.Node)
+
+	f = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "ul" {
+			ulCounter++
+			if ulCounter == 2 {
+				for c := n.FirstChild; c != nil; c = c.NextSibling {
+					if c.Type == html.ElementNode && c.Data == "li" {
+						for cc := c.FirstChild; cc != nil; cc = cc.NextSibling {
+							if cc.Type == html.ElementNode && cc.Data == "a" {
+								result = append(result, cc.FirstChild.Data)
+							}
+						}
+					}
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			f(c)
+		}
+	}
+
+	f(n)
+	return result
+}

--- a/v0/main.go
+++ b/v0/main.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"fmt"
+	"github.com/2ajoyce/dynamic-readme-elements/v0/internal"
 	"github.com/2ajoyce/dynamic-readme-elements/v0/internal/svggen"
 	"github.com/gin-gonic/gin"
-	"log/slog"
 	"net/http"
-	"runtime/debug"
 )
 
 func main() {
@@ -33,11 +31,7 @@ func main() {
 	})
 
 	// Route for version endpoint
-	router.GET("/version", func(c *gin.Context) {
-		info, _ := debug.ReadBuildInfo()
-		slog.Debug(fmt.Sprintf("BuildInfo:\n%+v", info))
-		c.JSON(http.StatusOK, gin.H{"version": info.Main.Version})
-	})
+	router.GET("/version", internal.HandleVersion)
 
 	err := router.Run(":8080")
 	if err != nil {


### PR DESCRIPTION
Decoupled the commit and version information logic from the main functionality into a separate `vcs.go` file within the internal package.

This provides better maintainability and separation of concerns. The new `HandleVersion` function is utilized in the '/version' route handler instead of the inline function previously defined in the Gin route setup.

Also modified the Dockerfile by changing the base Golang image and directory structure for building the Docker image. This allows the vcs information to be embedded in the build

No additional actions required unless extending functionality related to the '/version' route or the Docker configuration.

Closes #7