### PR TITLE
fix(svggen): Corrected month rendering in SVG calendar

### DIFF
--- a/v0/internal/svggen/calendar.go
+++ b/v0/internal/svggen/calendar.go
@@ -11,28 +11,28 @@ import (
 )
 
 const calendarChartTemplateStr = `
-		<svg width="370px" height="310px" xmlns="http://www.w3.org/2000/svg" font-family="Arial">
-			<!-- Background with rounded corners and padding -->
-			<rect x="5" y="5" width="360px" height="300px" fill="white" rx="15" />
+	<svg width="370px" height="{{.Height}}px" xmlns="http://www.w3.org/2000/svg" font-family="Arial">
+		<!-- Background with rounded corners and padding -->
+		<rect x="5" y="5" width="360px" height="300px" fill="white" rx="15" />
 
-			<!-- Header for month and year -->
-			<text x="180" y="35" font-size="20" text-anchor="middle" fill="black">{{.MonthName}} {{.Year}}</text>
+		<!-- Header for month and year -->
+		<text x="180" y="35" font-size="20" text-anchor="middle" fill="black">{{.MonthName}} {{.Year}}</text>
 
-			{{- $startDay := .StartDay -}}
-			{{- $daysInMonth := .DaysInMonth -}}
-			{{- $progressDays := .ProgressDays -}}
+		{{- $startDay := .StartDay -}}
+		{{- $daysInMonth := .DaysInMonth -}}
+		{{- $progressDays := .ProgressDays -}}
 
-			<!-- Generating the grid -->
-			{{- range $i := seq 1 $daysInMonth -}}
-				{{- $positionIndex := add (add $i $startDay) -1 -}}
-				{{- $x := mod $positionIndex 7 -}}
-				{{- $y := div $positionIndex 7 -}}
-				{{- $isProgress := hasElem $progressDays $i -}}
-				<rect x="{{add (mult $x 50) 15}}" y="{{add (mult $y 50) 45}}" width="40" height="40" fill="{{if $isProgress}}#4c1{{else}}#f0f0f0{{end}}" stroke="#ddd" />
-				<text x="{{add (mult $x 50) 35}}" y="{{add (mult $y 50) 70}}" font-size="14" text-anchor="middle" fill="{{if $isProgress}}white{{else}}black{{end}}">{{$i}}</text>
-			{{- end }}
-		</svg>
-		`
+		<!-- Generating the grid -->
+		{{- range $i := seq 1 $daysInMonth -}}
+			{{- $positionIndex := add (add $i $startDay) -1 -}}
+			{{- $x := mod $positionIndex 7 -}}
+			{{- $y := div $positionIndex 7 -}}
+			{{- $isProgress := hasElem $progressDays $i -}}
+			<rect x="{{add (mult $x 50) 15}}" y="{{add (mult $y 50) 45}}" width="40" height="40" fill="{{if $isProgress}}#4c1{{else}}#f0f0f0{{end}}" stroke="#ddd" />
+			<text x="{{add (mult $x 50) 35}}" y="{{add (mult $y 50) 70}}" font-size="14" text-anchor="middle" fill="{{if $isProgress}}white{{else}}black{{end}}">{{$i}}</text>
+		{{- end }}
+	</svg>
+	`
 
 func HandleCalendar(c *gin.Context) {
 	funcMap := template.FuncMap{
@@ -91,11 +91,17 @@ func HandleCalendar(c *gin.Context) {
 	lastDayOfMonth := firstDayOfMonth.AddDate(0, 1, -1)
 	daysInMonth := lastDayOfMonth.Day()
 
+	height := 310 // If the month has 5 weeks
+	if startDay+daysInMonth > 35 {
+		height = 360 // If the month has 6 weeks
+	}
+
 	// Prepare data for the template
 	data := struct {
 		Year, Month, StartDay, DaysInMonth int
 		MonthName                          string
 		ProgressDays                       []int
+		Height                             int
 	}{
 		Year:         year,
 		Month:        int(month),
@@ -103,6 +109,7 @@ func HandleCalendar(c *gin.Context) {
 		StartDay:     startDay,
 		DaysInMonth:  daysInMonth,
 		ProgressDays: progressDays,
+		Height:       height,
 	}
 
 	// Execute the template and write the response

--- a/v0/internal/svggen/calendar_test.go
+++ b/v0/internal/svggen/calendar_test.go
@@ -26,7 +26,7 @@ func TestHandleCalendar(t *testing.T) {
 			queryString:    "/calendar?year=2023&month=1&progressDays=1,15",
 			expectedStatus: http.StatusOK,
 			expectInBody: []string{
-				`<svg width="370px" height="310px" xmlns="http://www.w3.org/2000/svg" font-family="Arial">`,
+				`<svg width="370px" height="310px" xmlns="http://www.w3.org/2000/svg" font-family="Arial">`, // Height for 5wk month
 				`<rect x="5" y="5" width="360px" height="300px" fill="white" rx="15" />`,                    // Background
 				`<text x="180" y="35" font-size="20" text-anchor="middle" fill="black">January 2023</text>`, // Header
 				// Check for a few specific days, including one that is marked as progress and one that is not
@@ -34,6 +34,22 @@ func TestHandleCalendar(t *testing.T) {
 				`<text x="35" y="70" font-size="14" text-anchor="middle" fill="white">1</text>`, // Text for Day 1
 				`<rect x="65" y="45" width="40" height="40" fill="#f0f0f0" stroke="#ddd" />`,    // Day 2 without progress
 				`<text x="85" y="70" font-size="14" text-anchor="middle" fill="black">2</text>`, // Text for Day 2
+			},
+		},
+		{
+			name:           "Check height when month has 6 weeks",
+			queryString:    "/calendar?year=2023&month=4",
+			expectedStatus: http.StatusOK,
+			expectInBody: []string{
+				`<svg width="370px" height="360px" xmlns="http://www.w3.org/2000/svg" font-family="Arial">`,
+			},
+		},
+		{
+			name:           "Check height when month has ALMOST 6 weeks",
+			queryString:    "/calendar?year=2024&month=8",
+			expectedStatus: http.StatusOK,
+			expectInBody: []string{
+				`<svg width="370px" height="310px" xmlns="http://www.w3.org/2000/svg" font-family="Arial">`,
 			},
 		},
 		{


### PR DESCRIPTION
Corrected an issue in `HandleCalendar` function where the SVG template assumed that all months have exactly 5 weeks. This led to incorrect rendering of months that spread over 6 weeks.

The SVG’s height is now dynamic and will accommodate 6 rows of weeks if necessary, based on the start day and the number of days in the month. Additionally, to handle SVG positioning, the range and rect element values within the SVG code got modified to cater to instances where a 6th week requires a display.

Closes #4