### PR TITLE
fix(svggen): Updated background dimensions

### DIFF
--- a/v0/internal/svggen/calendar.go
+++ b/v0/internal/svggen/calendar.go
@@ -13,7 +13,7 @@ import (
 const calendarChartTemplateStr = `
 	<svg width="370px" height="{{.Height}}px" xmlns="http://www.w3.org/2000/svg" font-family="Arial">
 		<!-- Background with rounded corners and padding -->
-		<rect x="5" y="5" width="360px" height="300px" fill="white" rx="15" />
+		<rect x="5" y="5" width="360px" height="{{add .Height -10}}px" fill="white" rx="15" />
 
 		<!-- Header for month and year -->
 		<text x="180" y="35" font-size="20" text-anchor="middle" fill="black">{{.MonthName}} {{.Year}}</text>


### PR DESCRIPTION
Updated background dimensions so that it fully encompasses months with 6 weeks when viewed in dark mode.

Closes #10

![image](https://github.com/2ajoyce/dynamic-readme-elements/assets/12161102/8f61bca1-2977-4ad9-aecb-739fe60849aa)
![image](https://github.com/2ajoyce/dynamic-readme-elements/assets/12161102/bce16235-31e6-444c-aa31-e12920ee2bd6)
